### PR TITLE
PS-3860 Split client 

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,6 +4,8 @@ parameters:
     paths:
         - src
         - tests
-    ignoreErrors:
+    stubFiles:
+        - tests/stubs/Guzzle.stub
+
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,156 +4,21 @@ declare(strict_types=1);
 
 namespace Keboola\BillingApi;
 
-use Closure;
-use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\MessageFormatter;
-use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Request;
-use Keboola\BillingApi\Exception\BillingException;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Range;
-use Symfony\Component\Validator\Constraints\Url;
-use Symfony\Component\Validator\ConstraintViolationInterface;
-use Symfony\Component\Validator\Validation;
-use Throwable;
 
 class Client
 {
-    private const DEFAULT_USER_AGENT = 'Billing PHP Client';
-    private const DEFAULT_BACKOFF_RETRIES = 10;
-    private const CONNECT_TIMEOUT = 10;
-    private const CONNECT_RETRIES = 0;
-    private const TRANSFER_TIMEOUT = 120;
+    private InternalClient $internalClient;
 
-    protected GuzzleClient $guzzle;
-
-    public function __construct(
-        string $billingUrl,
-        string $storageToken,
-        array $options = []
-    ) {
-        $validator = Validation::createValidator();
-        $errors = $validator->validate($billingUrl, [new Url()]);
-        $errors->addAll(
-            $validator->validate($billingUrl, [new NotBlank()])
-        );
-        $errors->addAll(
-            $validator->validate($storageToken, [new NotBlank()])
-        );
-        if (!empty($options['backoffMaxTries'])) {
-            $errors->addAll($validator->validate($options['backoffMaxTries'], [new Range(['min' => 0, 'max' => 100])]));
-            $options['backoffMaxTries'] = intval($options['backoffMaxTries']);
-        } else {
-            $options['backoffMaxTries'] = self::DEFAULT_BACKOFF_RETRIES;
-        }
-        if (empty($options['userAgent'])) {
-            $options['userAgent'] = self::DEFAULT_USER_AGENT;
-        }
-        if ($errors->count() !== 0) {
-            $messages = '';
-            /** @var ConstraintViolationInterface $error */
-            foreach ($errors as $error) {
-                $messages .= 'Value "' . $error->getInvalidValue() . '" is invalid: ' . $error->getMessage() . "\n";
-            }
-            throw new BillingException('Invalid parameters when creating client: ' . $messages);
-        }
-        $this->guzzle = $this->initClient($billingUrl, $storageToken, $options);
+    public function __construct(InternalClient $internalClient)
+    {
+        $this->internalClient = $internalClient;
     }
 
     public function getRemainingCredits(): float
     {
         $request = new Request('GET', 'credits', []);
-        $data = $this->sendRequest($request);
+        $data = $this->internalClient->sendRequest($request);
         return (double) $data['remaining'];
-    }
-
-    public function recordJobDuration(string $projectId, string $jobId, float $durationSeconds): array
-    {
-        $request = new Request('PUT', 'duration/job', [], json_encode([
-            'projectId' => $projectId,
-            'jobId' => $jobId,
-            'durationSeconds' => $durationSeconds,
-        ], JSON_THROW_ON_ERROR));
-        return $this->sendRequest($request);
-    }
-
-    private function createDefaultDecider(int $maxRetries): Closure
-    {
-        return function (
-            int $retries,
-            RequestInterface $request,
-            ?ResponseInterface $response = null,
-            ?Throwable $error = null
-        ) use ($maxRetries) {
-            if ($retries >= $maxRetries) {
-                return false;
-            } elseif ($response && $response->getStatusCode() >= 500) {
-                return true;
-            } elseif ($error) {
-                return true;
-            } else {
-                return false;
-            }
-        };
-    }
-
-    private function initClient(string $url, string $token, array $options = []): GuzzleClient
-    {
-        // Initialize handlers (start with those supplied in constructor)
-        if (isset($options['handler']) && is_callable($options['handler'])) {
-            $handlerStack = HandlerStack::create($options['handler']);
-        } else {
-            $handlerStack = HandlerStack::create();
-        }
-        // Set exponential backoff
-        $handlerStack->push(Middleware::retry($this->createDefaultDecider($options['backoffMaxTries'])));
-        // Set handler to set default headers
-        $handlerStack->push(Middleware::mapRequest(
-            function (RequestInterface $request) use ($token, $options) {
-                return $request
-                    ->withHeader('User-Agent', $options['userAgent'])
-                    ->withHeader('X-StorageApi-Token', $token)
-                    ->withHeader('Content-type', 'application/json');
-            }
-        ));
-        // Set client logger
-        if (isset($options['logger']) && $options['logger'] instanceof LoggerInterface) {
-            $handlerStack->push(Middleware::log(
-                $options['logger'],
-                new MessageFormatter(
-                    '{hostname} {req_header_User-Agent} - [{ts}] "{method} {resource} {protocol}/{version}"' .
-                    ' {code} {res_header_Content-Length}'
-                )
-            ));
-        }
-        // finally create the instance
-        return new GuzzleClient(
-            [
-                'base_uri' => $url,
-                'handler' => $handlerStack,
-                'retries' => self::CONNECT_RETRIES,
-                'connect_timeout' => self::CONNECT_TIMEOUT,
-                'timeout' => self::TRANSFER_TIMEOUT,
-            ]
-        );
-    }
-
-    private function sendRequest(Request $request): array
-    {
-        try {
-            $response = $this->guzzle->send($request);
-            $data = (array) json_decode($response->getBody()->getContents(), true);
-            if (json_last_error() !== JSON_ERROR_NONE) {
-                throw new BillingException('Unable to parse response body into JSON: ' . json_last_error_msg());
-            }
-            return $data ?: [];
-        } catch (GuzzleException $e) {
-            throw new BillingException($e->getMessage(), $e->getCode(), $e);
-        }
     }
 }

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\BillingApi;
+
+class ClientFactory
+{
+    public function createClient(
+        string $billingUrl,
+        string $authToken,
+        array $options = []
+    ): Client {
+        $internalClient = new InternalClient(
+            $billingUrl,
+            'X-StorageApi-Token',
+            $authToken,
+            $options
+        );
+
+        return new Client($internalClient);
+    }
+
+    public function createManageClient(
+        string $billingUrl,
+        string $authToken,
+        array $options = []
+    ): ManageClient {
+        $internalClient = new InternalClient(
+            $billingUrl,
+            'X-KBC-ManageApiToken',
+            $authToken,
+            $options
+        );
+
+        return new ManageClient($internalClient);
+    }
+}

--- a/src/CreditsChecker.php
+++ b/src/CreditsChecker.php
@@ -10,10 +10,12 @@ use Keboola\StorageApi\Options\IndexOptions;
 
 class CreditsChecker
 {
+    private ClientFactory $clientFactory;
     private StorageApiClient $client;
 
-    public function __construct(StorageApiClient $client)
+    public function __construct(ClientFactory $clientFactory, StorageApiClient $client)
     {
+        $this->clientFactory = $clientFactory;
         $this->client = $client;
     }
 
@@ -41,7 +43,7 @@ class CreditsChecker
             );
         }
 
-        return new Client($url, $token);
+        return $this->clientFactory->createClient($url, $token);
     }
 
     public function hasCredits(): bool

--- a/src/InternalClient.php
+++ b/src/InternalClient.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\BillingApi;
+
+use Closure;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\MessageFormatter;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use Keboola\BillingApi\Exception\BillingException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Range;
+use Symfony\Component\Validator\Constraints\Url;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\Validation;
+use Throwable;
+
+class InternalClient
+{
+    private const DEFAULT_USER_AGENT = 'Billing PHP Client';
+    private const DEFAULT_BACKOFF_RETRIES = 10;
+    private const CONNECT_TIMEOUT = 10;
+    private const CONNECT_RETRIES = 0;
+    private const TRANSFER_TIMEOUT = 120;
+
+    private GuzzleClient $guzzle;
+
+    public function __construct(
+        string $billingUrl,
+        string $authHeaderName,
+        string $authToken,
+        array $options = []
+    ) {
+        $validator = Validation::createValidator();
+        $errors = $validator->validate($billingUrl, [new Url()]);
+        $errors->addAll(
+            $validator->validate($billingUrl, [new NotBlank()])
+        );
+        $errors->addAll(
+            $validator->validate($authHeaderName, [new NotBlank()])
+        );
+        $errors->addAll(
+            $validator->validate($authToken, [new NotBlank()])
+        );
+        if (!empty($options['backoffMaxTries'])) {
+            $errors->addAll($validator->validate($options['backoffMaxTries'], [new Range(['min' => 0, 'max' => 100])]));
+            $options['backoffMaxTries'] = intval($options['backoffMaxTries']);
+        } else {
+            $options['backoffMaxTries'] = self::DEFAULT_BACKOFF_RETRIES;
+        }
+        if (empty($options['userAgent'])) {
+            $options['userAgent'] = self::DEFAULT_USER_AGENT;
+        }
+        if ($errors->count() !== 0) {
+            $messages = '';
+            /** @var ConstraintViolationInterface $error */
+            foreach ($errors as $error) {
+                $messages .= 'Value "' . $error->getInvalidValue() . '" is invalid: ' . $error->getMessage() . "\n";
+            }
+            throw new BillingException('Invalid parameters when creating client: ' . $messages);
+        }
+        $this->guzzle = $this->initClient($billingUrl, $authHeaderName, $authToken, $options);
+    }
+
+    public function sendRequest(Request $request): array
+    {
+        try {
+            $response = $this->guzzle->send($request);
+            $data = (array) json_decode($response->getBody()->getContents(), true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new BillingException('Unable to parse response body into JSON: ' . json_last_error_msg());
+            }
+            return $data ?: [];
+        } catch (GuzzleException $e) {
+            throw new BillingException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    private function initClient(
+        string $url,
+        string $authHeaderName,
+        string $authToken,
+        array $options = []
+    ): GuzzleClient {
+        // Initialize handlers (start with those supplied in constructor)
+        if (isset($options['handler']) && is_callable($options['handler'])) {
+            $handlerStack = HandlerStack::create($options['handler']);
+        } else {
+            $handlerStack = HandlerStack::create();
+        }
+        // Set exponential backoff
+        $handlerStack->push(Middleware::retry($this->createDefaultDecider($options['backoffMaxTries'])));
+        // Set handler to set default headers
+        $handlerStack->push(Middleware::mapRequest(
+            function (RequestInterface $request) use ($authHeaderName, $authToken, $options) {
+                return $request
+                    ->withHeader('User-Agent', $options['userAgent'])
+                    ->withHeader($authHeaderName, $authToken)
+                    ->withHeader('Content-type', 'application/json');
+            }
+        ));
+        // Set client logger
+        if (isset($options['logger']) && $options['logger'] instanceof LoggerInterface) {
+            $handlerStack->push(Middleware::log(
+                $options['logger'],
+                new MessageFormatter(
+                    '{hostname} {req_header_User-Agent} - [{ts}] "{method} {resource} {protocol}/{version}"' .
+                    ' {code} {res_header_Content-Length}'
+                )
+            ));
+        }
+        // finally create the instance
+        return new GuzzleClient(
+            [
+                'base_uri' => $url,
+                'handler' => $handlerStack,
+                'retries' => self::CONNECT_RETRIES,
+                'connect_timeout' => self::CONNECT_TIMEOUT,
+                'timeout' => self::TRANSFER_TIMEOUT,
+            ]
+        );
+    }
+
+    private function createDefaultDecider(int $maxRetries): Closure
+    {
+        return function (
+            int $retries,
+            RequestInterface $request,
+            ?ResponseInterface $response = null,
+            ?Throwable $error = null
+        ) use ($maxRetries) {
+            if ($retries >= $maxRetries) {
+                return false;
+            } elseif ($response && $response->getStatusCode() >= 500) {
+                return true;
+            } elseif ($error) {
+                return true;
+            } else {
+                return false;
+            }
+        };
+    }
+}

--- a/src/ManageClient.php
+++ b/src/ManageClient.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\BillingApi;
+
+use Closure;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\MessageFormatter;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use Keboola\BillingApi\Exception\BillingException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Range;
+use Symfony\Component\Validator\Constraints\Url;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\Validation;
+use Throwable;
+
+class ManageClient
+{
+    private InternalClient $internalClient;
+
+    public function __construct(InternalClient $internalClient)
+    {
+        $this->internalClient = $internalClient;
+    }
+
+    public function recordJobDuration(string $projectId, string $jobId, float $durationSeconds): array
+    {
+        $request = new Request('PUT', 'duration/job', [], json_encode([
+            'projectId' => $projectId,
+            'jobId' => $jobId,
+            'durationSeconds' => $durationSeconds,
+        ], JSON_THROW_ON_ERROR));
+        return $this->internalClient->sendRequest($request);
+    }
+}

--- a/tests/Unit/ClientTest.php
+++ b/tests/Unit/ClientTest.php
@@ -7,301 +7,44 @@ namespace Tests\Keboola\BillingApi\Unit;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
-use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Keboola\BillingApi\Client;
-use Keboola\BillingApi\Exception\BillingException;
+use Keboola\BillingApi\InternalClient;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
-use Psr\Log\Test\TestLogger;
 
 class ClientTest extends TestCase
 {
-    private function getClient(array $options): Client
-    {
-        return new Client(
-            'https://example.com/',
-            'testToken',
-            $options
-        );
-    }
-
-    public function testCreateClientInvalidBackoff(): void
-    {
-        $this->expectException(BillingException::class);
-        $this->expectExceptionMessage(
-            'Invalid parameters when creating client: Value "abc" is invalid: This value should be a valid number'
-        );
-        new Client(
-            'https://example.com/',
-            'testToken',
-            ['backoffMaxTries' => 'abc']
-        );
-    }
-
-    public function testCreateClientTooLowBackoff(): void
-    {
-        $this->expectException(BillingException::class);
-        $this->expectExceptionMessage(
-            'Invalid parameters when creating client: Value "-1" is invalid: This value should be between 0 and 100.'
-        );
-        new Client(
-            'https://example.com/',
-            'testToken',
-            ['backoffMaxTries' => -1]
-        );
-    }
-
-    public function testCreateClientTooHighBackoff(): void
-    {
-        $this->expectException(BillingException::class);
-        $this->expectExceptionMessage(
-            'Invalid parameters when creating client: Value "101" is invalid: This value should be between 0 and 100.'
-        );
-        new Client(
-            'https://example.com/',
-            'testToken',
-            ['backoffMaxTries' => 101]
-        );
-    }
-
-    public function testCreateClientInvalidToken(): void
-    {
-        $this->expectException(BillingException::class);
-        $this->expectExceptionMessage(
-            'Invalid parameters when creating client: Value "" is invalid: This value should not be blank.'
-        );
-        new Client('https://example.com/', '');
-    }
-
-    public function testCreateClientInvalidUrl(): void
-    {
-        $this->expectException(BillingException::class);
-        $this->expectExceptionMessage(
-            'Invalid parameters when creating client: Value "invalid url" is invalid: This value is not a valid URL.'
-        );
-        new Client('invalid url', 'testToken');
-    }
-
-    public function testCreateClientMultipleErrors(): void
-    {
-        $this->expectException(BillingException::class);
-        $this->expectExceptionMessage(
-            'Invalid parameters when creating client: Value "invalid url" is invalid: This value is not a valid URL.'
-        );
-        new Client('invalid url', '');
-    }
-
-    public function testClientRequestResponse(): void
-    {
-        $mock = new MockHandler([
-            new Response(
-                200,
-                ['Content-Type' => 'application/json'],
-                '{
-                    "remaining": "123.4343434343434343",
-                    "consumed": "456.1212121212121212"
-                }'
-            ),
-        ]);
-        // Add the history middleware to the handler stack.
-        $requestHistory = [];
-        $history = Middleware::history($requestHistory);
-        $stack = HandlerStack::create($mock);
-        $stack->push($history);
-        $client = $this->getClient(['handler' => $stack]);
-        $credits = $client->getRemainingCredits();
-        self::assertEqualsWithDelta(123.43434343434, $credits, 0.00001);
-        self::assertCount(1, $requestHistory);
-
-        $request = $requestHistory[0]['request'];
-        self::assertInstanceOf(Request::class, $request);
-        self::assertEquals('https://example.com/credits', $request->getUri()->__toString());
-        self::assertEquals('GET', $request->getMethod());
-        self::assertEquals('testToken', $request->getHeader('X-StorageApi-Token')[0]);
-        self::assertEquals('Billing PHP Client', $request->getHeader('User-Agent')[0]);
-        self::assertEquals('application/json', $request->getHeader('Content-type')[0]);
-    }
-
-    public function testInvalidResponse(): void
-    {
-        $mock = new MockHandler([
-            new Response(
-                200,
-                ['Content-Type' => 'application/json'],
-                'invalid json'
-            ),
-        ]);
-        // Add the history middleware to the handler stack.
-        $requestHistory = [];
-        $history = Middleware::history($requestHistory);
-        $stack = HandlerStack::create($mock);
-        $stack->push($history);
-        $client = $this->getClient(['handler' => $stack]);
-        self::expectException(BillingException::class);
-        self::expectExceptionMessage('Unable to parse response body into JSON: Syntax error');
-        $client->getRemainingCredits();
-    }
-
-    public function testLogger(): void
-    {
-        $mock = new MockHandler([
-            new Response(
-                200,
-                ['Content-Type' => 'application/json'],
-                '{
-                    "remaining": "123",
-                    "consumed": "456"
-                }'
-            ),
-        ]);
-        // Add the history middleware to the handler stack.
-        $requestHistory = [];
-        $history = Middleware::history($requestHistory);
-        $stack = HandlerStack::create($mock);
-        $stack->push($history);
-        $logger = new TestLogger();
-        $client = $this->getClient(['handler' => $stack, 'logger' => $logger, 'userAgent' => 'test agent']);
-        $client->getRemainingCredits();
-
-        $request = $requestHistory[0]['request'];
-        self::assertInstanceOf(Request::class, $request);
-        self::assertEquals('test agent', $request->getHeader('User-Agent')[0]);
-        self::assertTrue($logger->hasInfoThatContains('"GET  /1.1" 200 '));
-        self::assertTrue($logger->hasInfoThatContains('test agent'));
-    }
-
-    public function testRetrySuccess(): void
-    {
-        $mock = new MockHandler([
-            new Response(
-                500,
-                ['Content-Type' => 'application/json'],
-                '{"message" => "Out of order"}'
-            ),
-            new Response(
-                500,
-                ['Content-Type' => 'application/json'],
-                'Out of order'
-            ),
-            new Response(
-                200,
-                ['Content-Type' => 'application/json'],
-                '{
-                    "remaining": "123",
-                    "consumed": "456"
-                }'
-            ),
-        ]);
-        // Add the history middleware to the handler stack.
-        $requestHistory = [];
-        $history = Middleware::history($requestHistory);
-        $stack = HandlerStack::create($mock);
-        $stack->push($history);
-        $client = $this->getClient(['handler' => $stack]);
-        $credits = $client->getRemainingCredits();
-
-        self::assertEquals('123', $credits);
-        self::assertCount(3, $requestHistory);
-        $request = $requestHistory[0]['request'];
-        self::assertInstanceOf(Request::class, $request);
-        self::assertEquals('https://example.com/credits', $request->getUri()->__toString());
-        $request = $requestHistory[1]['request'];
-        self::assertEquals('https://example.com/credits', $request->getUri()->__toString());
-        $request = $requestHistory[2]['request'];
-        self::assertEquals('https://example.com/credits', $request->getUri()->__toString());
-    }
-
-    public function testRetryFailure(): void
-    {
-        $responses = [];
-        for ($i = 0; $i < 30; $i++) {
-            $responses[] = new Response(
-                500,
-                ['Content-Type' => 'application/json'],
-                '{"message" => "Out of order"}'
-            );
-        }
-        $mock = new MockHandler($responses);
-        // Add the history middleware to the handler stack.
-        $requestHistory = [];
-        $history = Middleware::history($requestHistory);
-        $stack = HandlerStack::create($mock);
-        $stack->push($history);
-        $client = $this->getClient(['handler' => $stack, 'backoffMaxTries' => 1]);
-        try {
-            $client->getRemainingCredits();
-            self::fail('Must throw exception');
-        } catch (BillingException $e) {
-            self::assertStringContainsString('500 Internal Server Error', $e->getMessage());
-        }
-        self::assertCount(2, $requestHistory);
-    }
-
-    public function testRetryFailureReducedBackoff(): void
-    {
-        $responses = [];
-        for ($i = 0; $i < 30; $i++) {
-            $responses[] = new Response(
-                500,
-                ['Content-Type' => 'application/json'],
-                '{"message" => "Out of order"}'
-            );
-        }
-        $mock = new MockHandler($responses);
-        // Add the history middleware to the handler stack.
-        $requestHistory = [];
-        $history = Middleware::history($requestHistory);
-        $stack = HandlerStack::create($mock);
-        $stack->push($history);
-        $client = $this->getClient(['handler' => $stack, 'backoffMaxTries' => 3]);
-        try {
-            $client->getRemainingCredits();
-            self::fail('Must throw exception');
-        } catch (BillingException $e) {
-            self::assertStringContainsString('500 Internal Server Error', $e->getMessage());
-        }
-        self::assertCount(4, $requestHistory);
-    }
-
-    public function testRecordJobDuration(): void
+    public function testGetRemainingCredits(): void
     {
         $requestsMade = [];
         $responses = [
-            new Response(200, [], (string) json_encode([
-                'projectId' => 'project-id',
-                'jobId' => 'job-id',
-                'durationSeconds' => 72.7,
-            ])),
+            new Response(200, [], '
+                {
+                    "remaining": "123.4343434343434343",
+                    "consumed": "456.1212121212121212"
+                }
+            '),
         ];
 
         $handlerStack = HandlerStack::create(new MockHandler($responses));
         $handlerStack->push(Middleware::history($requestsMade));
-        $client = new Client('http://example.com', 'dummy-token', [
+        $internalClient = new InternalClient('http://example.com', 'auth-header', 'dummy-token', [
             'handler' => $handlerStack,
         ]);
 
-        $result = $client->recordJobDuration('project-id', 'job-id', 72.7);
+        $client = new Client($internalClient);
+
+        $result = $client->getRemainingCredits();
 
         self::assertCount(1, $requestsMade);
         $request = $requestsMade[0]['request'];
 
         self::assertInstanceOf(RequestInterface::class, $request);
-        self::assertSame('PUT', $request->getMethod());
-        self::assertSame('http://example.com/duration/job', (string) $request->getUri());
-        self::assertSame(
-            json_encode([
-                'projectId' => 'project-id',
-                'jobId' => 'job-id',
-                'durationSeconds' => 72.7,
-            ]),
-            (string) $request->getBody()
-        );
+        self::assertSame('GET', $request->getMethod());
+        self::assertSame('http://example.com/credits', (string) $request->getUri());
+        self::assertSame('dummy-token', $request->getHeaderLine('auth-header'));
 
-        self::assertSame([
-            'projectId' => 'project-id',
-            'jobId' => 'job-id',
-            'durationSeconds' => 72.7,
-        ], $result);
+        self::assertEqualsWithDelta(123.43434343434, $result, 0.00001);
     }
 }

--- a/tests/Unit/CreditsCheckerTest.php
+++ b/tests/Unit/CreditsCheckerTest.php
@@ -6,6 +6,7 @@ namespace Tests\Keboola\BillingApi\Unit;
 
 use Generator;
 use Keboola\BillingApi\Client;
+use Keboola\BillingApi\ClientFactory;
 use Keboola\BillingApi\CreditsChecker;
 use Keboola\StorageApi\Client as StorageApiClient;
 use Keboola\StorageApi\Options\IndexOptions;
@@ -34,7 +35,7 @@ class CreditsCheckerTest extends TestCase
                     ],
                 ],
             ]);
-        $creditsChecker = new CreditsChecker($storageApiClient);
+        $creditsChecker = new CreditsChecker(new ClientFactory(), $storageApiClient);
         $this->assertTrue($creditsChecker->hasCredits());
     }
 
@@ -69,7 +70,7 @@ class CreditsCheckerTest extends TestCase
             ]
         );
 
-        $creditsChecker = new CreditsChecker($storageApiClient);
+        $creditsChecker = new CreditsChecker(new ClientFactory(), $storageApiClient);
         self::assertTrue($creditsChecker->hasCredits());
     }
 
@@ -121,7 +122,7 @@ class CreditsCheckerTest extends TestCase
         $billingClient->method('getRemainingCredits')->willReturn($remainingCredits);
         $creditsChecker = self::getMockBuilder(CreditsChecker::class)
             ->setMethods(['getBillingClient'])
-            ->setConstructorArgs([$storageApiClient])
+            ->setConstructorArgs([new ClientFactory(), $storageApiClient])
             ->getMock();
         $creditsChecker->method('getBillingClient')
             ->willReturn($billingClient);

--- a/tests/Unit/InternalClientTest.php
+++ b/tests/Unit/InternalClientTest.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Keboola\BillingApi\Unit;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Keboola\BillingApi\Client;
+use Keboola\BillingApi\Exception\BillingException;
+use Keboola\BillingApi\InternalClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Log\Test\TestLogger;
+
+class InternalClientTest extends TestCase
+{
+    private function getClient(array $options): InternalClient
+    {
+        return new InternalClient(
+            'https://example.com/',
+            'authHeader',
+            'authToken',
+            $options
+        );
+    }
+
+    public function testCreateClientInvalidBackoff(): void
+    {
+        $this->expectException(BillingException::class);
+        $this->expectExceptionMessage(
+            'Invalid parameters when creating client: Value "abc" is invalid: This value should be a valid number'
+        );
+        new InternalClient(
+            'https://example.com/',
+            'authHeader',
+            'authToken',
+            ['backoffMaxTries' => 'abc']
+        );
+    }
+
+    public function testCreateClientTooLowBackoff(): void
+    {
+        $this->expectException(BillingException::class);
+        $this->expectExceptionMessage(
+            'Invalid parameters when creating client: Value "-1" is invalid: This value should be between 0 and 100.'
+        );
+        new InternalClient(
+            'https://example.com/',
+            'authHeader',
+            'authToken',
+            ['backoffMaxTries' => -1]
+        );
+    }
+
+    public function testCreateClientTooHighBackoff(): void
+    {
+        $this->expectException(BillingException::class);
+        $this->expectExceptionMessage(
+            'Invalid parameters when creating client: Value "101" is invalid: This value should be between 0 and 100.'
+        );
+        new InternalClient(
+            'https://example.com/',
+            'authHeader',
+            'authToken',
+            ['backoffMaxTries' => 101]
+        );
+    }
+
+    public function testCreateClientInvalidUrl(): void
+    {
+        $this->expectException(BillingException::class);
+        $this->expectExceptionMessage(
+            'Invalid parameters when creating client: Value "invalid url" is invalid: This value is not a valid URL.'
+        );
+        new InternalClient('invalid url', 'authHeader', 'authToken');
+    }
+
+    public function testCreateClientInvalidAuthHeader(): void
+    {
+        $this->expectException(BillingException::class);
+        $this->expectExceptionMessage(
+            'Invalid parameters when creating client: Value "" is invalid: This value should not be blank.'
+        );
+        new InternalClient('https://example.com/', '', 'authToken');
+    }
+
+    public function testCreateClientInvalidAuthToken(): void
+    {
+        $this->expectException(BillingException::class);
+        $this->expectExceptionMessage(
+            'Invalid parameters when creating client: Value "" is invalid: This value should not be blank.'
+        );
+        new InternalClient('https://example.com/', 'authHeader', '');
+    }
+
+    public function testCreateClientMultipleErrors(): void
+    {
+        $this->expectException(BillingException::class);
+        $this->expectExceptionMessage(
+            'Invalid parameters when creating client: Value "invalid url" is invalid: This value is not a valid URL.'
+        );
+        new InternalClient('invalid url', '', '');
+    }
+
+    public function testClientRequestResponse(): void
+    {
+        $mock = new MockHandler([
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                '{
+                    "remaining": "123.4343434343434343",
+                    "consumed": "456.1212121212121212"
+                }'
+            ),
+        ]);
+        // Add the history middleware to the handler stack.
+        $requestHistory = [];
+        $history = Middleware::history($requestHistory);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
+
+        $client = $this->getClient(['handler' => $stack]);
+        $response = $client->sendRequest(new Request('GET', 'credits'));
+
+        self::assertSame([
+            'remaining' => '123.4343434343434343',
+            'consumed' => '456.1212121212121212',
+        ], $response);
+
+        self::assertCount(1, $requestHistory);
+
+        $request = $requestHistory[0]['request'];
+        self::assertInstanceOf(Request::class, $request);
+        self::assertEquals('https://example.com/credits', $request->getUri()->__toString());
+        self::assertEquals('GET', $request->getMethod());
+        self::assertEquals('authToken', $request->getHeader('authHeader')[0]);
+        self::assertEquals('Billing PHP Client', $request->getHeader('User-Agent')[0]);
+        self::assertEquals('application/json', $request->getHeader('Content-type')[0]);
+    }
+
+    public function testInvalidResponse(): void
+    {
+        $mock = new MockHandler([
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                'invalid json'
+            ),
+        ]);
+        // Add the history middleware to the handler stack.
+        $requestHistory = [];
+        $history = Middleware::history($requestHistory);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
+
+        $client = $this->getClient(['handler' => $stack]);
+
+        $this->expectException(BillingException::class);
+        $this->expectExceptionMessage('Unable to parse response body into JSON: Syntax error');
+        $client->sendRequest(new Request('GET', 'credits'));
+    }
+
+    public function testLogger(): void
+    {
+        $mock = new MockHandler([
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                '{
+                    "remaining": "123",
+                    "consumed": "456"
+                }'
+            ),
+        ]);
+        // Add the history middleware to the handler stack.
+        $requestHistory = [];
+        $history = Middleware::history($requestHistory);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
+        $logger = new TestLogger();
+        $client = $this->getClient(['handler' => $stack, 'logger' => $logger, 'userAgent' => 'test agent']);
+        $client->sendRequest(new Request('GET', 'credits'));
+
+        $request = $requestHistory[0]['request'];
+        self::assertInstanceOf(Request::class, $request);
+        self::assertEquals('test agent', $request->getHeader('User-Agent')[0]);
+        self::assertTrue($logger->hasInfoThatContains('"GET  /1.1" 200 '));
+        self::assertTrue($logger->hasInfoThatContains('test agent'));
+    }
+
+    public function testRetrySuccess(): void
+    {
+        $mock = new MockHandler([
+            new Response(
+                500,
+                ['Content-Type' => 'application/json'],
+                '{"message" => "Out of order"}'
+            ),
+            new Response(
+                500,
+                ['Content-Type' => 'application/json'],
+                'Out of order'
+            ),
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                '{
+                    "remaining": "123",
+                    "consumed": "456"
+                }'
+            ),
+        ]);
+        // Add the history middleware to the handler stack.
+        $requestHistory = [];
+        $history = Middleware::history($requestHistory);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
+        $client = $this->getClient(['handler' => $stack]);
+        $response = $client->sendRequest(new Request('GET', 'credits'));
+
+        self::assertSame([
+            'remaining' => '123',
+            'consumed' => '456',
+        ], $response);
+
+        self::assertCount(3, $requestHistory);
+        $request = $requestHistory[0]['request'];
+        self::assertInstanceOf(Request::class, $request);
+        self::assertEquals('https://example.com/credits', $request->getUri()->__toString());
+        $request = $requestHistory[1]['request'];
+        self::assertEquals('https://example.com/credits', $request->getUri()->__toString());
+        $request = $requestHistory[2]['request'];
+        self::assertEquals('https://example.com/credits', $request->getUri()->__toString());
+    }
+
+    public function testRetryFailure(): void
+    {
+        $responses = [];
+        for ($i = 0; $i < 30; $i++) {
+            $responses[] = new Response(
+                500,
+                ['Content-Type' => 'application/json'],
+                '{"message" => "Out of order"}'
+            );
+        }
+        $mock = new MockHandler($responses);
+        // Add the history middleware to the handler stack.
+        $requestHistory = [];
+        $history = Middleware::history($requestHistory);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
+        $client = $this->getClient(['handler' => $stack, 'backoffMaxTries' => 1]);
+        try {
+            $client->sendRequest(new Request('GET', 'credits'));
+            self::fail('Must throw exception');
+        } catch (BillingException $e) {
+            self::assertStringContainsString('500 Internal Server Error', $e->getMessage());
+        }
+        self::assertCount(2, $requestHistory);
+    }
+
+    public function testRetryFailureReducedBackoff(): void
+    {
+        $responses = [];
+        for ($i = 0; $i < 30; $i++) {
+            $responses[] = new Response(
+                500,
+                ['Content-Type' => 'application/json'],
+                '{"message" => "Out of order"}'
+            );
+        }
+        $mock = new MockHandler($responses);
+        // Add the history middleware to the handler stack.
+        $requestHistory = [];
+        $history = Middleware::history($requestHistory);
+        $stack = HandlerStack::create($mock);
+        $stack->push($history);
+        $client = $this->getClient(['handler' => $stack, 'backoffMaxTries' => 3]);
+        try {
+            $client->sendRequest(new Request('GET', 'credits'));
+            self::fail('Must throw exception');
+        } catch (BillingException $e) {
+            self::assertStringContainsString('500 Internal Server Error', $e->getMessage());
+        }
+        self::assertCount(4, $requestHistory);
+    }
+}

--- a/tests/Unit/InternalClientTest.php
+++ b/tests/Unit/InternalClientTest.php
@@ -38,6 +38,7 @@ class InternalClientTest extends TestCase
             'https://example.com/',
             'authHeader',
             'authToken',
+            // @phpstan-ignore-next-line we test passing invalid value
             ['backoffMaxTries' => 'abc']
         );
     }
@@ -52,6 +53,7 @@ class InternalClientTest extends TestCase
             'https://example.com/',
             'authHeader',
             'authToken',
+            // @phpstan-ignore-next-line we test passing invalid value
             ['backoffMaxTries' => -1]
         );
     }
@@ -66,6 +68,7 @@ class InternalClientTest extends TestCase
             'https://example.com/',
             'authHeader',
             'authToken',
+            // @phpstan-ignore-next-line we test passing invalid value
             ['backoffMaxTries' => 101]
         );
     }

--- a/tests/Unit/ManageClientTest.php
+++ b/tests/Unit/ManageClientTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Keboola\BillingApi\Unit;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Keboola\BillingApi\InternalClient;
+use Keboola\BillingApi\ManageClient;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class ManageClientTest extends TestCase
+{
+    public function testRecordJobDuration(): void
+    {
+        $requestsMade = [];
+        $responses = [
+            new Response(200, [], (string) json_encode([
+                'projectId' => 'project-id',
+                'jobId' => 'job-id',
+                'durationSeconds' => 72.7,
+            ])),
+        ];
+
+        $handlerStack = HandlerStack::create(new MockHandler($responses));
+        $handlerStack->push(Middleware::history($requestsMade));
+        $internalClient = new InternalClient('http://example.com', 'auth-header', 'dummy-token', [
+            'handler' => $handlerStack,
+        ]);
+
+        $client = new ManageClient($internalClient);
+
+        $result = $client->recordJobDuration('project-id', 'job-id', 72.7);
+
+        self::assertCount(1, $requestsMade);
+        $request = $requestsMade[0]['request'];
+
+        self::assertInstanceOf(RequestInterface::class, $request);
+        self::assertSame('PUT', $request->getMethod());
+        self::assertSame('http://example.com/duration/job', (string) $request->getUri());
+        self::assertSame('dummy-token', $request->getHeaderLine('auth-header'));
+        self::assertSame(
+            json_encode([
+                'projectId' => 'project-id',
+                'jobId' => 'job-id',
+                'durationSeconds' => 72.7,
+            ]),
+            (string) $request->getBody()
+        );
+
+        self::assertSame([
+            'projectId' => 'project-id',
+            'jobId' => 'job-id',
+            'durationSeconds' => 72.7,
+        ], $result);
+    }
+}

--- a/tests/stubs/Guzzle.stub
+++ b/tests/stubs/Guzzle.stub
@@ -1,0 +1,27 @@
+<?php
+
+namespace GuzzleHttp
+{
+
+    use GuzzleHttp\Promise\PromiseInterface;
+    use Psr\Http\Message\RequestInterface;
+
+    class HandlerStack
+    {
+        /**
+         * @return PromiseInterface
+         * @param array<mixed> $options
+         */
+        public function __invoke(RequestInterface $request, array $options) {}
+    }
+}
+
+namespace GuzzleHttp\Promise
+{
+    interface PromiseInterface {}
+}
+
+namespace Psr\Http\Message
+{
+    interface RequestInterface {}
+}


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PS-3860

Endpoint na zaznamenani consumption vyzaduje manage token. Nechat to oboje v jedny `Client` class mi prislo prasacky, protoze storage a amange token nemuze byt nikdy stejny, tak jsem to rozdelel na 2 klienty podobne jako to mame v Sandboxes API (jen jsem nepouzil dedicnost pro sdileni kodu, ale udelal navic internal clienta).

Pokud by byl nejaky napad na lepsi pojmenovani te `Client` class, povidejte..