### PR TITLE
MAR-90 `resolveToken` return full subscription details

### DIFF
--- a/src/Model/ResolveTokenResult.php
+++ b/src/Model/ResolveTokenResult.php
@@ -4,23 +4,48 @@ declare(strict_types=1);
 
 namespace Keboola\BillingApi\Model;
 
+use DateTimeImmutable;
+
 class ResolveTokenResult
 {
+    public const VENDOR_AWS = 'aws';
+    public const VENDOR_AZURE = 'azure';
+    public const VENDOR_GCP = 'gcp';
+
+    public const STATE_INACTIVE = 'inactive';
+    public const STATE_ACTIVE = 'active';
+    public const STATE_SUSPENDED = 'suspended';
+    public const STATE_UNSUBSCRIBED = 'unsubscribed';
+
     public function __construct(
-        public readonly string $subscriptionId,
-        public readonly array $subscriptionData,
+        public readonly string $id,
+        public readonly string $vendor,
+        public readonly string $vendorSubscriptionId,
+        public readonly ?string $productId,
+        public readonly string $planId,
+        public readonly string $state,
         public readonly ?string $organizationId,
         public readonly ?string $projectId,
+        public readonly DateTimeImmutable $dateCreated,
+        public readonly DateTimeImmutable $dateModified,
+        public readonly array $vendorData,
     ) {
     }
 
     public static function fromResponse(array $data): self
     {
         return new self(
-            $data['subscriptionId'],
-            $data['subscriptionData'],
+            $data['id'],
+            $data['vendor'],
+            $data['vendorSubscriptionId'],
+            $data['productId'] ?? null,
+            $data['planId'],
+            $data['state'],
             $data['organizationId'] ?? null,
             $data['projectId'] ?? null,
+            new DateTimeImmutable($data['dateCreated']),
+            new DateTimeImmutable($data['dateModified']),
+            $data['vendorData'],
         );
     }
 }

--- a/tests/Model/ResolveTokenResultTest.php
+++ b/tests/Model/ResolveTokenResultTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Keboola\BillingApi\Model;
+
+use Keboola\BillingApi\Model\ResolveTokenResult;
+use PHPUnit\Framework\TestCase;
+
+class ResolveTokenResultTest extends TestCase
+{
+    public function testFromResponse(): void
+    {
+        $result = ResolveTokenResult::fromResponse([
+            'id' => '123',
+            'vendor' => 'aws',
+            'vendorSubscriptionId' => '456',
+            'productId' => '789',
+            'planId' => 'plan',
+            'state' => 'active',
+            'organizationId' => 'org',
+            'projectId' => 'proj',
+            'dateCreated' => '2021-01-01T00:00:00+00:00',
+            'dateModified' => '2022-01-01T00:00:00+00:00',
+            'vendorData' => [
+                'foo' => 'bar',
+            ],
+        ]);
+
+        self::assertSame('123', $result->id);
+        self::assertSame('aws', $result->vendor);
+        self::assertSame('456', $result->vendorSubscriptionId);
+        self::assertSame('789', $result->productId);
+        self::assertSame('plan', $result->planId);
+        self::assertSame('active', $result->state);
+        self::assertSame('org', $result->organizationId);
+        self::assertSame('proj', $result->projectId);
+        self::assertSame('2021-01-01T00:00:00+00:00', $result->dateCreated->format(DATE_ATOM));
+        self::assertSame('2022-01-01T00:00:00+00:00', $result->dateModified->format(DATE_ATOM));
+        self::assertSame(['foo' => 'bar'], $result->vendorData);
+    }
+}

--- a/tests/Unit/ManageClientTest.php
+++ b/tests/Unit/ManageClientTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Keboola\BillingApi\Unit;
 
+use DateTimeImmutable;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
@@ -134,22 +135,17 @@ class ManageClientTest extends TestCase
                 'token' => 'token-value',
             ],
             'responseData' => [
-                'subscriptionId' => 'subscription-id',
-                'subscriptionData' => [
-                    'subscription' => [
-                        'beneficiary' => [
-                            'tenantId' => 'tenant-id',
-                        ],
-                    ],
-                    'offerId' => 123,
-                    'planId' => 123,
-                ],
+                'id' => 'subscription-id',
+                'vendor' => 'aws',
+                'vendorSubscriptionId' => '456',
+                'productId' => '789',
+                'planId' => 'plan',
+                'state' => 'inactive',
                 'organizationId' => null,
                 'projectId' => null,
-            ],
-            'expectedResult' => new ResolveTokenResult(
-                'subscription-id',
-                [
+                'dateCreated' => '2021-01-01T00:00:00+00:00',
+                'dateModified' => '2022-01-01T00:00:00+00:00',
+                'vendorData' => [
                     'subscription' => [
                         'beneficiary' => [
                             'tenantId' => 'tenant-id',
@@ -158,8 +154,27 @@ class ManageClientTest extends TestCase
                     'offerId' => 123,
                     'planId' => 123,
                 ],
-                null,
-                null,
+            ],
+            'expectedResult' => new ResolveTokenResult(
+                id: 'subscription-id',
+                vendor: 'aws',
+                vendorSubscriptionId: '456',
+                productId: '789',
+                planId: 'plan',
+                state: 'inactive',
+                organizationId: null,
+                projectId: null,
+                dateCreated: new DateTimeImmutable('2021-01-01T00:00:00+00:00'),
+                dateModified: new DateTimeImmutable('2022-01-01T00:00:00+00:00'),
+                vendorData: [
+                    'subscription' => [
+                        'beneficiary' => [
+                            'tenantId' => 'tenant-id',
+                        ],
+                    ],
+                    'offerId' => 123,
+                    'planId' => 123,
+                ],
             ),
         ];
 
@@ -173,22 +188,17 @@ class ManageClientTest extends TestCase
                 'token' => 'token-value',
             ],
             'responseData' => [
-                'subscriptionId' => 'subscription-id',
-                'subscriptionData' => [
-                    'subscription' => [
-                        'beneficiary' => [
-                            'tenantId' => 'tenant-id',
-                        ],
-                    ],
-                    'offerId' => 123,
-                    'planId' => 123,
-                ],
+                'id' => 'subscription-id',
+                'vendor' => 'aws',
+                'vendorSubscriptionId' => '456',
+                'productId' => '789',
+                'planId' => 'plan',
+                'state' => 'inactive',
                 'organizationId' => 'organization-id',
                 'projectId' => 'project-id',
-            ],
-            'expectedResult' => new ResolveTokenResult(
-                'subscription-id',
-                [
+                'dateCreated' => '2021-01-01T00:00:00+00:00',
+                'dateModified' => '2022-01-01T00:00:00+00:00',
+                'vendorData' => [
                     'subscription' => [
                         'beneficiary' => [
                             'tenantId' => 'tenant-id',
@@ -197,8 +207,27 @@ class ManageClientTest extends TestCase
                     'offerId' => 123,
                     'planId' => 123,
                 ],
-                'organization-id',
-                'project-id',
+            ],
+            'expectedResult' => new ResolveTokenResult(
+                id: 'subscription-id',
+                vendor: 'aws',
+                vendorSubscriptionId: '456',
+                productId: '789',
+                planId: 'plan',
+                state: 'inactive',
+                organizationId: 'organization-id',
+                projectId: 'project-id',
+                dateCreated: new DateTimeImmutable('2021-01-01T00:00:00+00:00'),
+                dateModified: new DateTimeImmutable('2022-01-01T00:00:00+00:00'),
+                vendorData: [
+                    'subscription' => [
+                        'beneficiary' => [
+                            'tenantId' => 'tenant-id',
+                        ],
+                    ],
+                    'offerId' => 123,
+                    'planId' => 123,
+                ],
             ),
         ];
     }


### PR DESCRIPTION
https://keboola.atlassian.net/browse/MAR-90
Depends on https://github.com/keboola/billing-api/pull/173

`resolveToken` endpoint vraci komplet detail subscription. Bude to chtit zase major release, protoze nektery fieldy na response jsou prejmenovany (`subscriptionId` -> `id`, `subscriptionData` -> `vendorData`) a nechceme drzet zbytecne dlouho BC.